### PR TITLE
docs: update key access

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -29,7 +29,7 @@
 
 In order to run the application, run the `generate-keys.sh` in the root directory.
 
-Make sure to add trust the `key.pem` on your local machine.
+Make sure to add trust the `cert.pem` and `ca-cert.pem` on your local machine.
 
 ##### MacOS
 The keys should go under your `system keychain` and you should set the trust level to `Always Trust`.


### PR DESCRIPTION
This pull request updates the `docs/development/README.md` file to clarify which certificate files need to be trusted on the local machine during setup.

Documentation update:

* Updated the instructions to specify that both `cert.pem` and `ca-cert.pem` need to be trusted on the local machine instead of just `key.pem`.

Solves docs