### PR TITLE
feat(helm): add comprehensive deployment configuration options

### DIFF
--- a/charts/office-add-in/templates/backend-deployment.yaml
+++ b/charts/office-add-in/templates/backend-deployment.yaml
@@ -11,11 +11,23 @@ spec:
       {{- include "office-add-in.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.backend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "office-add-in.backend.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
       containers:
         - name: backend
+          securityContext:
+            {{- toYaml .Values.backend.securityContext | nindent 12 }}
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.backend.image.pullPolicy }}"
           ports:
@@ -25,3 +37,17 @@ spec:
               value: {{ .Values.backend.jwtSecret | quote }}
             - name: API_BASE_URL
               value: {{ .Values.backend.apiBaseUrl | quote }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/office-add-in/templates/frontend-deployment.yaml
+++ b/charts/office-add-in/templates/frontend-deployment.yaml
@@ -11,11 +11,23 @@ spec:
       {{- include "office-add-in.frontend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.frontend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "office-add-in.frontend.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.frontend.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
       containers:
         - name: frontend
+          securityContext:
+            {{- toYaml .Values.frontend.securityContext | nindent 12 }}
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: "{{ .Values.frontend.image.pullPolicy }}"
           ports:
@@ -39,3 +51,17 @@ spec:
               port: 80
             initialDelaySeconds: 15
             periodSeconds: 10
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/office-add-in/values.yaml
+++ b/charts/office-add-in/values.yaml
@@ -13,6 +13,39 @@ frontend:
   enableHttps: false
   # -- Maximum content body size (e.g. for attachments)
   maxBodySize: 80M
+  # -- Resource limits and requests for the frontend container
+  resources: {}
+    # We usually recommend not specifying default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  # -- Pod annotations for the frontend deployment
+  podAnnotations: {}
+  # -- Pod security context for the frontend deployment
+  podSecurityContext: {}
+    # fsGroup: 2000
+  # -- Security context for the frontend container
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  # -- Node selector for the frontend deployment
+  nodeSelector: {}
+  # -- Affinity rules for the frontend deployment
+  affinity: {}
+  # -- Tolerations for the frontend deployment
+  tolerations: []
+  # -- Image pull secrets for the frontend deployment
+  imagePullSecrets: []
 
 backend:
   image:
@@ -26,3 +59,36 @@ backend:
   jwtSecret: "SECRECT_KEY_PLACEHOLDER"
   # -- Base URL to the openzaak API
   apiBaseUrl: "http://localhost:8020"
+  # -- Resource limits and requests for the backend container
+  resources: {}
+    # We usually recommend not specifying default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  # -- Pod annotations for the backend deployment
+  podAnnotations: {}
+  # -- Pod security context for the backend deployment
+  podSecurityContext: {}
+    # fsGroup: 2000
+  # -- Security context for the backend container
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+  # -- Node selector for the backend deployment
+  nodeSelector: {}
+  # -- Affinity rules for the backend deployment
+  affinity: {}
+  # -- Tolerations for the backend deployment
+  tolerations: []
+  # -- Image pull secrets for the backend deployment
+  imagePullSecrets: []


### PR DESCRIPTION
Add support for production-ready Kubernetes deployment options to both frontend and backend services in the Helm chart:

- resources: CPU and memory limits/requests
- podAnnotations: custom pod annotations
- securityContext: container-level security settings
- podSecurityContext: pod-level security settings
- nodeSelector: node selection constraints
- affinity: pod affinity/anti-affinity rules
- tolerations: node taint tolerations
- imagePullSecrets: private registry authentication

These options enable proper production deployments with security, resource management, and scheduling controls.

Solves: PZ-8777