### PR TITLE
fix: unique office and outlook manifest names

### DIFF
--- a/office-add-in/entrypoint.sh
+++ b/office-add-in/entrypoint.sh
@@ -51,8 +51,8 @@ if [ "$APP_ENV" = "production" ]; then
   ENV_INDICATOR=""
   ENV_DESCRIPTION=""
 else
-  ENV_INDICATOR="($APP_ENV)"
-  ENV_DESCRIPTION="Specifiek voor omgeving $APP_ENV."
+  ENV_INDICATOR=" ($APP_ENV)"
+  ENV_DESCRIPTION=" Specifiek voor omgeving $APP_ENV."
 fi
 
 # Optionally set the frontend URL to use, defaults to https://localhost:3000.

--- a/office-add-in/entrypoint.sh
+++ b/office-add-in/entrypoint.sh
@@ -45,14 +45,30 @@ if [ -z "$MSAL_CLIENT_ID" ] || [ "$MSAL_CLIENT_ID" = "your-client-id" ]; then
   exit 1
 fi
 
+# Function to escape XML special characters (POSIX-compatible)
+xml_escape() {
+  printf '%s' "$1" | \
+    sed -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g' \
+        -e "s/'/\&apos;/g"
+}
+
 # Determine the display name based on the application environment.
 # For production, we use a simple name, for other environments we append the environment name for clarity.
 if [ "$APP_ENV" = "production" ]; then
   ENV_INDICATOR=""
   ENV_DESCRIPTION=""
+  ENV_INDICATOR_ESCAPED_FOR_SED=""
+  ENV_DESCRIPTION_ESCAPED_FOR_SED=""
 else
-  ENV_INDICATOR=" ($APP_ENV)"
-  ENV_DESCRIPTION=" Specifiek voor omgeving $APP_ENV."
+  APP_ENV_XML_SAFE="$(xml_escape "$APP_ENV")"
+  ENV_INDICATOR=" ($APP_ENV_XML_SAFE)"
+  ENV_DESCRIPTION=" Specifiek voor omgeving $APP_ENV_XML_SAFE."
+  # Escape & for sed replacement
+  ENV_INDICATOR_ESCAPED_FOR_SED=$(printf '%s' "$ENV_INDICATOR" | sed 's/&/\\&/g')
+  ENV_DESCRIPTION_ESCAPED_FOR_SED=$(printf '%s' "$ENV_DESCRIPTION" | sed 's/&/\\&/g')
 fi
 
 # Optionally set the frontend URL to use, defaults to https://localhost:3000.
@@ -72,8 +88,8 @@ for MANIFEST_FILE in "$MANIFEST_OFFICE_FILE" "$MANIFEST_OUTLOOK_FILE"; do
   sed -i -e "s|https://${TO_REPLACE_URL}|${FRONTEND_URL}|g" "$MANIFEST_FILE"
   sed -i -e "s|api://${TO_REPLACE_URL}/${TO_REPLACE_CLIENT_ID}|$FRONTEND_API|g" "$MANIFEST_FILE"
   sed -i -e "s|<Id>${TO_REPLACE_CLIENT_ID}</Id>|<Id>${MSAL_CLIENT_ID}</Id>|g" "$MANIFEST_FILE"
-  sed -i -e "s|${TO_REPLACE_ENV_INDICATOR}|${ENV_INDICATOR}|g" "$MANIFEST_FILE"
-  sed -i -e "s|${TO_REPLACE_ENV_DESCRIPTION}|${ENV_DESCRIPTION}|g" "$MANIFEST_FILE"
+  sed -i -e "s|${TO_REPLACE_ENV_INDICATOR}|${ENV_INDICATOR_ESCAPED_FOR_SED}|g" "$MANIFEST_FILE"
+  sed -i -e "s|${TO_REPLACE_ENV_DESCRIPTION}|${ENV_DESCRIPTION_ESCAPED_FOR_SED}|g" "$MANIFEST_FILE"
 done
 
 ####

--- a/office-add-in/entrypoint.sh
+++ b/office-add-in/entrypoint.sh
@@ -33,7 +33,8 @@ NGINX_CONFIG_FILE="${NGINX_CONFIG_FILE:-/etc/nginx/conf.d/default.conf}"
 # These have to match exactly with the used values in the manifest files!
 TO_REPLACE_CLIENT_ID="10000000-0001-1001-1001-100000000001"
 TO_REPLACE_URL="localhost:3000"
-TO_REPLACE_DISPLAY_NAME="TO_REPLACE_DISPLAY_NAME"
+TO_REPLACE_ENV_INDICATOR="TO_REPLACE_ENV_INDICATOR"
+TO_REPLACE_ENV_DESCRIPTION="TO_REPLACE_ENV_DESCRIPTION"
 
 # MSAL client ID has be set via environment variables.
 MSAL_CLIENT_ID="${MSAL_CLIENT_ID:-your-client-id}"
@@ -47,9 +48,11 @@ fi
 # Determine the display name based on the application environment.
 # For production, we use a simple name, for other environments we append the environment name for clarity.
 if [ "$APP_ENV" = "production" ]; then
-  DISPLAY_NAME="ZGW Office Add-in"
+  ENV_INDICATOR=""
+  ENV_DESCRIPTION=""
 else
-  DISPLAY_NAME="ZGW Office Add-in ($APP_ENV)"
+  ENV_INDICATOR="($APP_ENV)"
+  ENV_DESCRIPTION="Specifiek voor omgeving $APP_ENV."
 fi
 
 # Optionally set the frontend URL to use, defaults to https://localhost:3000.
@@ -61,14 +64,16 @@ MANIFEST_OUTLOOK_FILE="${NGINX_PUBLIC_HTML}/manifest-outlook.xml"
 echo "MSAL Client ID is set to ${MSAL_CLIENT_ID}."
 echo "Frontend URL is set to ${FRONTEND_URL}."
 echo "Frontend API is set to ${FRONTEND_API}."
-echo "Display name for manifest is set to ${DISPLAY_NAME}."
+echo "Display name for manifest is appended with '${ENV_INDICATOR}'."
+echo "Description for manifest is appended with '${ENV_DESCRIPTION}'."
 for MANIFEST_FILE in "$MANIFEST_OFFICE_FILE" "$MANIFEST_OUTLOOK_FILE"; do
   [ -f "$MANIFEST_FILE" ] || continue
   sed -i -e "s|http://${TO_REPLACE_URL}|${FRONTEND_URL}|g" "$MANIFEST_FILE"
   sed -i -e "s|https://${TO_REPLACE_URL}|${FRONTEND_URL}|g" "$MANIFEST_FILE"
   sed -i -e "s|api://${TO_REPLACE_URL}/${TO_REPLACE_CLIENT_ID}|$FRONTEND_API|g" "$MANIFEST_FILE"
   sed -i -e "s|<Id>${TO_REPLACE_CLIENT_ID}</Id>|<Id>${MSAL_CLIENT_ID}</Id>|g" "$MANIFEST_FILE"
-  sed -i -e "s|${TO_REPLACE_DISPLAY_NAME}|${DISPLAY_NAME}|g" "$MANIFEST_FILE"
+  sed -i -e "s|${TO_REPLACE_ENV_INDICATOR}|${ENV_INDICATOR}|g" "$MANIFEST_FILE"
+  sed -i -e "s|${TO_REPLACE_ENV_DESCRIPTION}|${ENV_DESCRIPTION}|g" "$MANIFEST_FILE"
 done
 
 ####

--- a/office-add-in/entrypoint.test.sh
+++ b/office-add-in/entrypoint.test.sh
@@ -3,6 +3,11 @@
 # SPDX-FileCopyrightText: 2025 INFO.nl
 # SPDX-License-Identifier: EUPL-1.2+
 #
+
+# Ensure the script runs from its own directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
+cd "$SCRIPT_DIR" || exit
+
 # Simple script to test the entrypoint script in a controlled environment.
 #
 # There are no automated checks, so the user has to manually verify the replacement is correct.
@@ -62,7 +67,7 @@ export MAX_BODY_SIZE="555M"
 export APP_VERSION="test-version"
 
 # environment
-export APP_ENV="test-entrypoint-env"
+export APP_ENV="test&entrypoint<env>"
 export MSAL_CLIENT_ID="696724da-f71f-40c4-9dce-53ab2bc8e0cb"
 export MSAL_AUTHORITY="https://login.microsoftonline.com/5ac40c21-50a2-414f-93d1-495d1324322b"
 export MSAL_REDIRECT_URI="http://localhost:3000"

--- a/office-add-in/manifest-office.xml
+++ b/office-add-in/manifest-office.xml
@@ -10,8 +10,8 @@
   <Version>1.0.0</Version>
   <ProviderName>INFO.nl</ProviderName>
   <DefaultLocale>nl-NL</DefaultLocale>
-  <DisplayName DefaultValue="ZGW Office Add-in TO_REPLACE_ENV_INDICATOR" />
-  <Description DefaultValue="ZGW Office integratie add-in. TO_REPLACE_ENV_DESCRIPTION" />
+  <DisplayName DefaultValue="ZGW Office Add-inTO_REPLACE_ENV_INDICATOR" />
+  <Description DefaultValue="ZGW Office integratie add-in.TO_REPLACE_ENV_DESCRIPTION" />
   <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png" />
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-64.png" />
   <SupportUrl DefaultValue="https://www.info.nl/" />

--- a/office-add-in/manifest-office.xml
+++ b/office-add-in/manifest-office.xml
@@ -10,8 +10,8 @@
   <Version>1.0.0</Version>
   <ProviderName>INFO.nl</ProviderName>
   <DefaultLocale>nl-NL</DefaultLocale>
-  <DisplayName DefaultValue="TO_REPLACE_DISPLAY_NAME" />
-  <Description DefaultValue="ZGW Office integratie add-in." />
+  <DisplayName DefaultValue="ZGW Office Add-in TO_REPLACE_ENV_INDICATOR" />
+  <Description DefaultValue="ZGW Office integratie add-in. TO_REPLACE_ENV_DESCRIPTION" />
   <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png" />
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-64.png" />
   <SupportUrl DefaultValue="https://www.info.nl/" />

--- a/office-add-in/manifest-outlook.xml
+++ b/office-add-in/manifest-outlook.xml
@@ -10,8 +10,8 @@
   <Version>1.0.0</Version>
   <ProviderName>INFO.nl</ProviderName>
   <DefaultLocale>nl-NL</DefaultLocale>
-  <DisplayName DefaultValue="ZGW Outlook Add-in TO_REPLACE_ENV_INDICATOR" />
-  <Description DefaultValue="ZGW Outlook integratie add-in. TO_REPLACE_ENV_DESCRIPTION" />
+  <DisplayName DefaultValue="ZGW Outlook Add-inTO_REPLACE_ENV_INDICATOR" />
+  <Description DefaultValue="ZGW Outlook integratie add-in.TO_REPLACE_ENV_DESCRIPTION" />
 
   <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png" />
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-64.png" />

--- a/office-add-in/manifest-outlook.xml
+++ b/office-add-in/manifest-outlook.xml
@@ -10,8 +10,8 @@
   <Version>1.0.0</Version>
   <ProviderName>INFO.nl</ProviderName>
   <DefaultLocale>nl-NL</DefaultLocale>
-  <DisplayName DefaultValue="TO_REPLACE_DISPLAY_NAME" />
-  <Description DefaultValue="ZGW Office integratie add-in." />
+  <DisplayName DefaultValue="ZGW Outlook Add-in TO_REPLACE_ENV_INDICATOR" />
+  <Description DefaultValue="ZGW Outlook integratie add-in. TO_REPLACE_ENV_DESCRIPTION" />
 
   <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png" />
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-64.png" />


### PR DESCRIPTION
The DisplayName and Description are now distinct for in office and outlook manifests, with the environment indicator and description appended to the end.

Solves PZ-10886