### PR TITLE
fix: use deploy key in commit-version-update to bypass main branch ruleset

### DIFF
--- a/.github/workflows/build-release-deploy.yaml
+++ b/.github/workflows/build-release-deploy.yaml
@@ -279,6 +279,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Update package.json versions
         run: |


### PR DESCRIPTION
## Summary

- The `commit-version-update` job was failing because `GITHUB_TOKEN` is blocked by the repository ruleset that requires PRs before pushing to `main`
- Switched the checkout in that job to use a deploy key (`secrets.DEPLOY_KEY`) via the `ssh-key` input, which can be added as a bypass actor in the ruleset

## Setup required

Before this fix takes effect, the following one-time setup is needed:

1. Generate a key pair: `ssh-keygen -t ed25519 -C "zgw-office-addin deploy key"`
2. GitHub → Settings → **Deploy keys** → add the **public key** with "Allow write access"
3. GitHub → Settings → Rules → Rulesets → main ruleset → **Bypass list** → add "Deploy keys"
4. GitHub → Settings → Secrets → Actions → add the **private key** as secret `DEPLOY_KEY`

Relates to PZ-11509

## Test plan

- [x] Complete the one-time setup steps above
- [ ] Merge this PR and verify the `commit-version-update` job succeeds on the next run on `main`