### PR TITLE
feat(chart): support podLabels on frontend/backend pods

### DIFF
--- a/charts/office-add-in/Chart.yaml
+++ b/charts/office-add-in/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zgw-office-addin
 description: A Helm chart for deploying the zgw-office-addin (frontend and backend)
 type: application
-version: 0.0.88
+version: 0.0.89
 appVersion: 0.2.0

--- a/charts/office-add-in/README.md
+++ b/charts/office-add-in/README.md
@@ -1,6 +1,6 @@
 # zgw-office-addin
 
-![Version: 0.0.88](https://img.shields.io/badge/Version-0.0.88-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.0.89](https://img.shields.io/badge/Version-0.0.89-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the zgw-office-addin (frontend and backend)
 
@@ -37,6 +37,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | backend.msalSecret | string | `""` | Client secret for MSAL authentication towards Azure AD |
 | backend.nodeSelector | object | `{}` | Node selector for the backend deployment |
 | backend.podAnnotations | object | `{}` | Pod annotations for the backend deployment |
+| backend.podLabels | object | `{}` | Extra pod labels for the backend pod (merged over common.podLabels) |
 | backend.podSecurityContext | object | `{"fsGroup":10001}` | Pod security context for the backend deployment |
 | backend.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource limits and requests for the backend container |
 | backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | Security context for the backend container |
@@ -49,6 +50,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | common.frontendUrl | string | `"http://localhost:3000"` | The frontend public URL where the manifest files and static js file are served |
 | common.msalClientId | string | `""` | MS Azure Client ID assigned to the Office Add-in application |
 | common.msalTenantId | string | `""` | MS Azure Tenant ID of the Organization |
+| common.podLabels | object | `{}` | Extra pod labels applied to BOTH the frontend and backend pods. Useful for observability: set e.g. `app` / `service_name` so the pods are attributed to the add-in instead of the Helm release name in Grafana/Loki. |
 | frontend.affinity | object | `{}` | Affinity rules for the frontend deployment |
 | frontend.enableHttps | bool | `false` | If enabled nginx will also listen on port 443. You will need to volume map a key and certificate valid for your frontendUrl |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -58,6 +60,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | frontend.maxBodySize | string | `"80M"` | Maximum content body size (e.g. for attachments) |
 | frontend.nodeSelector | object | `{}` | Node selector for the frontend deployment |
 | frontend.podAnnotations | object | `{}` | Pod annotations for the frontend deployment |
+| frontend.podLabels | object | `{}` | Extra pod labels for the frontend pod (merged over common.podLabels) |
 | frontend.podSecurityContext | object | `{"fsGroup":10001}` | Pod security context for the frontend deployment |
 | frontend.resources | object | `{"limits":{"cpu":"250m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource limits and requests for the frontend container |
 | frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | Security context for the frontend container |

--- a/charts/office-add-in/templates/backend-deployment.yaml
+++ b/charts/office-add-in/templates/backend-deployment.yaml
@@ -16,13 +16,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "office-add-in.backend.selectorLabels" . | nindent 8 }}
         {{- with .Values.common.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.backend.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- /* selectorLabels rendered LAST so they always win on key collision
+               and keep matching spec.selector.matchLabels */}}
+        {{- include "office-add-in.backend.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/office-add-in/templates/backend-deployment.yaml
+++ b/charts/office-add-in/templates/backend-deployment.yaml
@@ -17,6 +17,12 @@ spec:
       {{- end }}
       labels:
         {{- include "office-add-in.backend.selectorLabels" . | nindent 8 }}
+        {{- with .Values.common.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.backend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/office-add-in/templates/frontend-deployment.yaml
+++ b/charts/office-add-in/templates/frontend-deployment.yaml
@@ -17,6 +17,12 @@ spec:
       {{- end }}
       labels:
         {{- include "office-add-in.frontend.selectorLabels" . | nindent 8 }}
+        {{- with .Values.common.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.frontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.frontend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/office-add-in/templates/frontend-deployment.yaml
+++ b/charts/office-add-in/templates/frontend-deployment.yaml
@@ -16,13 +16,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "office-add-in.frontend.selectorLabels" . | nindent 8 }}
         {{- with .Values.common.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.frontend.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- /* selectorLabels rendered LAST so they always win on key collision
+               and keep matching spec.selector.matchLabels */}}
+        {{- include "office-add-in.frontend.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.frontend.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/office-add-in/values.schema.json
+++ b/charts/office-add-in/values.schema.json
@@ -26,6 +26,9 @@
         "msalClientId": {
           "type": "string",
           "description": "MS Azure Client ID assigned to the Office Add-in application"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/podLabels"
         }
       }
     },
@@ -53,6 +56,9 @@
         },
         "podAnnotations": {
           "$ref": "#/$defs/podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/podLabels"
         },
         "podSecurityContext": {
           "$ref": "#/$defs/podSecurityContext"
@@ -112,6 +118,9 @@
         },
         "podAnnotations": {
           "$ref": "#/$defs/podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/podLabels"
         },
         "podSecurityContext": {
           "$ref": "#/$defs/podSecurityContext"
@@ -197,6 +206,11 @@
     "podAnnotations": {
       "type": "object",
       "description": "Pod annotations",
+      "additionalProperties": { "type": "string" }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Pod labels",
       "additionalProperties": { "type": "string" }
     },
     "podSecurityContext": {

--- a/charts/office-add-in/values.yaml
+++ b/charts/office-add-in/values.yaml
@@ -8,6 +8,10 @@ common:
   msalTenantId: ""
   # -- MS Azure Client ID assigned to the Office Add-in application
   msalClientId: ""
+  # -- Extra pod labels applied to BOTH the frontend and backend pods. Useful for
+  # observability: set e.g. `app` / `service_name` so the pods are attributed to
+  # the add-in instead of the Helm release name in Grafana/Loki.
+  podLabels: {}
 
 frontend:
   image:
@@ -32,6 +36,8 @@ frontend:
       memory: 64Mi
   # -- Pod annotations for the frontend deployment
   podAnnotations: {}
+  # -- Extra pod labels for the frontend pod (merged over common.podLabels)
+  podLabels: {}
   # -- Pod security context for the frontend deployment
   podSecurityContext:
     fsGroup: 10001
@@ -88,6 +94,8 @@ backend:
       memory: 128Mi
   # -- Pod annotations for the backend deployment
   podAnnotations: {}
+  # -- Extra pod labels for the backend pod (merged over common.podLabels)
+  podLabels: {}
   # -- Pod security context for the backend deployment
   podSecurityContext:
     fsGroup: 10001


### PR DESCRIPTION
## Add `podLabels` support to the office-add-in pods

### Why
The frontend/backend pods only carry `app.kubernetes.io/name: frontend|backend` + `app.kubernetes.io/instance: <release>`. In log/metrics pipelines that derive `app`/`service_name` from the release name, the pods show up under the **release name** (for Dimpact: `podiumd`) instead of the add-in. There is currently no way to add labels to the pods (no `podLabels`/`commonLabels`).

### What
- **`common.podLabels`** — applied to **both** frontend and backend pods.
- **`frontend.podLabels` / `backend.podLabels`** — per-component, merged on top of `common.podLabels`.
- Merged into `spec.template.metadata.labels` in both deployments.
- `values.yaml`: documented `podLabels: {}` defaults.
- `values.schema.json`: new `podLabels` def, wired into `common`/`frontend`/`backend` (schema is `additionalProperties: false`).
- `Chart.yaml`: `0.0.88` → `0.0.89`.

### Example
```yaml
common:
  podLabels:
    app: office-addin
    service_name: office-addin
```

Backwards compatible — defaults are empty, so no change unless set. Ref: Dimpact IN-2060.