### PR TITLE
fix(ci): resolve turbo via npm run in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm ci
 
       - name: Build application artifacts
-        run: npm run build && turbo docker:build
+        run: npm run build && npm run docker:build
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Problem
The nightly/manual E2E workflow fails on the "Build application artifacts" step with `turbo: command not found` (exit 127).

## Root cause
`turbo` is a local devDependency (`node_modules/.bin/turbo`), installed via `npm ci`. The workflow invoked it bare (`turbo docker:build`) in a plain `run:` step — unlike an `npm run` step, a plain shell step doesn't have `node_modules/.bin` prepended to `PATH`, so the bare command isn't resolvable. Reproduced locally with a stripped `PATH`.

## Fix
Root `package.json` already defines a `docker:build` script (`"docker:build": "turbo docker:build"`) for exactly this — use `npm run docker:build` instead of calling `turbo` directly.

## Test plan
- [x] Reproduced the failure locally with `env -i PATH="/usr/bin:/bin" sh -c 'turbo docker:build'` → `command not found`
- [x] Confirmed the fix works with a stripped `PATH` via `npm run docker:build`
- [x] Ran the full local e2e flow end-to-end (build, docker compose up, Playwright suite, teardown) — all 10 tests pass