### PR TITLE
feature: Update reviewers and enable automerge for patch-level updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "docker:enableMajor"
   ],
   "reviewers": [
-    "team:dimpact"
+    "team:team-geneve"
   ],
   "helm-values": {
     "managerFilePatterns": [
@@ -36,6 +36,16 @@
     }
   ],
   "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "patch",
+        "lockFileMaintenance"
+      ],
+      "automerge": true,
+      "description": [
+        "Automerge all patch-level updates and weekly lockfile maintenance. The renovate-approve GitHub app provides the required approving review"
+      ]
+    },
     {
       "groupName": "eslint",
       "matchPackageNames": ["eslint", "neostandard"],


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve review team assignment and automate dependency management for patch-level updates and lockfile maintenance. The main changes are:

**Review workflow:**
- Changed the default reviewers for Renovate PRs from `team:dimpact` to `team:team-geneve` to reflect the correct team ownership.

**Dependency automation:**
- Added a rule to automatically merge all patch-level updates and weekly lockfile maintenance, with the required review provided by the `renovate-approve` GitHub app.

Solves PZ-12002